### PR TITLE
update eslint config to type check everything

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,8 +10,8 @@ const eslintConfig = [
 	...compat.config({
 		extends: [
 			'eslint:recommended',
-			'plugin:@typescript-eslint/strict',
-			'plugin:@typescript-eslint/stylistic',
+			'plugin:@typescript-eslint/strict-type-checked',
+			'plugin:@typescript-eslint/stylistic-type-checked',
 			'next'
 		],
 	}),


### PR DESCRIPTION
The previous eslint config didn't enforce type checking.  Fix that.
